### PR TITLE
Update ApphudExtensions.swift

### DIFF
--- a/ApphudSDK/ApphudExtensions.swift
+++ b/ApphudSDK/ApphudExtensions.swift
@@ -43,7 +43,6 @@ private func apphudIsSimulator() -> Bool {
 
 internal func apphudDidMigrate() {
     UserDefaults.standard.set(true, forKey: "ApphudSubscriptionsMigrated")
-    UserDefaults.standard.synchronize()
 }
 
 internal func apphudShouldMigrate() -> Bool {
@@ -52,7 +51,6 @@ internal func apphudShouldMigrate() -> Bool {
 
 internal func apphudToUserDefaultsCache(dictionary: [String: String], key: String) {
     UserDefaults.standard.set(dictionary, forKey: key)
-    UserDefaults.standard.synchronize()
 }
 
 internal func apphudFromUserDefaultsCache(key: String) -> [String: String]? {


### PR DESCRIPTION
remove deprecated synchronize() calls (from header file:

-synchronize is deprecated and will be marked with the API_DEPRECATED macro in a future release.

     -synchronize blocks the calling thread until all in-progress set operations have completed. This is no longer necessary. Replacements for previous uses of -synchronize depend on what the intent of calling synchronize was. If you synchronized...
     - ...before reading in order to fetch updated values: remove the synchronize call
     - ...after writing in order to notify another program to read: the other program can use KVO to observe the default without needing to notify
     - ...before exiting in a non-app (command line tool, agent, or daemon) process: call CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
     - ...for any other reason: remove the synchronize call
     */
)