### PR TITLE
retry when on internet, make fetch and restore products blocks array

### DIFF
--- a/ApphudSDK.podspec
+++ b/ApphudSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ApphudSDK'
-  s.version          = '1.2'
+  s.version          = '1.2.1'
   s.summary          = 'Track and control iOS auto-renewable subscriptions.' 
   s.description      = 'Track, control and analyze iOS auto-renewable subscriptions with Apphud.'
   s.homepage         = 'https://github.com/apphud/ApphudSDK'

--- a/ApphudSDK/Apphud.swift
+++ b/ApphudSDK/Apphud.swift
@@ -10,7 +10,7 @@ import UIKit
 import StoreKit
 import UserNotifications
 
-internal let apphud_sdk_version = "1.2"
+internal let apphud_sdk_version = "1.2.1"
 
 public typealias ApphudEligibilityCallback = (([String: Bool]) -> Void)
 public typealias ApphudBoolCallback = ((Bool) -> Void)
@@ -282,7 +282,7 @@ final public class Apphud: NSObject {
     You can use `productsDidFetchCallback` callback or observe for `didFetchProductsNotification()` or implement `apphudDidFetchStoreKitProducts` delegate method. Use whatever you like most.
     */
     @objc public static func productsDidFetchCallback(_ callback: @escaping ([SKProduct]) -> Void) {
-        ApphudStoreKitWrapper.shared.customProductsFetchedBlock = callback
+        ApphudStoreKitWrapper.shared.customProductsFetchedBlocks.append(callback)
     }
 
     /**

--- a/ApphudSDK/ApphudHttpClient.swift
+++ b/ApphudSDK/ApphudHttpClient.swift
@@ -259,7 +259,8 @@ public class ApphudHttpClient {
                     
                     callback?(false, nil, finalError, code)
                 } else {
-                    callback?(false, nil, error, 0)
+                    let code = (error as NSError?)?.code ?? NSURLErrorUnknown
+                    callback?(false, nil, error, code)
                 }
             }
         }

--- a/ApphudSDK/ApphudInternal+Product.swift
+++ b/ApphudSDK/ApphudInternal+Product.swift
@@ -15,13 +15,13 @@ extension ApphudInternal {
         if let productIDs = delegate?.apphudProductIdentifiers?(), productIDs.count > 0 {
             var map = [String: String]()
             productIDs.forEach { id in map[id] = "Untitled" }
-            continueWithProductsMap(map)
+            continueWithProductsMap(map, errorCode: nil)
         } else {
-            getProducts { map in  self.continueWithProductsMap(map) }
+            getProducts { map, code in  self.continueWithProductsMap(map, errorCode: code) }
         }
     }
     
-    fileprivate func continueWithProductsMap(_ productsGroupsMap: [String: String]?) {
+    fileprivate func continueWithProductsMap(_ productsGroupsMap: [String: String]?, errorCode: Int?) {
         // perform even if productsGroupsMap is nil or empty
         self.performAllProductGroupsFetchedCallbacks()
 
@@ -33,11 +33,12 @@ extension ApphudInternal {
         if self.productsGroupsMap?.keys.count ?? 0 > 0 {
             self.continueToFetchStoreKitProducts()
         } else {
-            self.scheduleProductsFetchRetry()
+            let noInternetErrorCode = errorCode == NSURLErrorNotConnectedToInternet
+            self.scheduleProductsFetchRetry(noInternetErrorCode)
         }
     }
 
-    fileprivate func scheduleProductsFetchRetry() {
+    fileprivate func scheduleProductsFetchRetry(_ noInternetError: Bool) {
         guard httpClient.canRetry else {
             return
         }
@@ -45,8 +46,17 @@ extension ApphudInternal {
             apphudLog("Reached max number of product fetch retries \(productsFetchRetriesCount). Exiting..", forceDisplay: true)
             return
         }
-        productsFetchRetriesCount += 1
-        let delay: TimeInterval = TimeInterval(productsFetchRetriesCount * 5)
+        
+        let delay: TimeInterval
+
+        if noInternetError {
+            delay = 2.0
+        } else {
+            delay = 5.0
+            userRegisterRetriesCount += 1
+        }
+        
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(continueToFetchProducts), object: nil)
         perform(#selector(continueToFetchProducts), with: nil, afterDelay: delay)
         apphudLog("No Product Identifiers found in Apphud. Probably you forgot to add products in Apphud Settings? Scheduled products fetch retry in \(delay) seconds.", forceDisplay: true)
     }
@@ -73,7 +83,7 @@ extension ApphudInternal {
 
     internal func refreshStoreKitProductsWithCallback(callback: (([SKProduct]) -> Void)?) {
 
-        ApphudStoreKitWrapper.shared.customProductsFetchedBlock = callback
+        callback.map{ ApphudStoreKitWrapper.shared.customProductsFetchedBlocks.append($0) }
 
         if self.currentUser == nil {
             continueToRegisteringUser()
@@ -84,9 +94,9 @@ extension ApphudInternal {
         }
     }
 
-    private func getProducts(callback: @escaping (([String: String]?) -> Void)) {
+    private func getProducts(callback: @escaping (([String: String]?, Int) -> Void)) {
 
-        httpClient.startRequest(path: "products", params: nil, method: .get) { (result, response, _, _) in
+        httpClient.startRequest(path: "products", params: ["device_id": currentDeviceID], method: .get) { (result, response, _, code) in
             if result, let dataDict = response?["data"] as? [String: Any],
                 let productsArray = dataDict["results"] as? [[String: Any]] {
 
@@ -97,9 +107,9 @@ extension ApphudInternal {
                     let groupID = (product["group_id"] as? String) ?? ""
                     map[productID] = groupID
                 }
-                callback(map)
+                callback(map, code)
             } else {
-                callback(nil)
+                callback(nil, code)
             }
         }
     }

--- a/ApphudSDK/ApphudInternal+UserUpdate.swift
+++ b/ApphudSDK/ApphudInternal+UserUpdate.swift
@@ -51,11 +51,11 @@ extension ApphudInternal {
         }
     }
 
-    internal func createOrGetUser(shouldUpdateUserID: Bool, callback: @escaping (Bool) -> Void) {
+    internal func createOrGetUser(shouldUpdateUserID: Bool, callback: @escaping (Bool, Int) -> Void) {
 
         let fields = shouldUpdateUserID ? ["user_id": self.currentUserID] : [:]
 
-        self.updateUser(fields: fields) { (result, response, error, _) in
+        self.updateUser(fields: fields) { (result, response, error, code) in
 
             let hasChanges = self.parseUser(response)
 
@@ -77,7 +77,7 @@ extension ApphudInternal {
                 apphudLog("Failed to register or get user, error:\(error!.localizedDescription)", forceDisplay: true)
             }
 
-            callback(finalResult)
+            callback(finalResult, code)
         }
     }
 
@@ -130,7 +130,7 @@ extension ApphudInternal {
     }
 
     @objc internal func updateCurrentUser() {
-        createOrGetUser(shouldUpdateUserID: false) { _ in
+        createOrGetUser(shouldUpdateUserID: false) { _, _ in
             self.lastCheckDate = Date()
         }
     }

--- a/ApphudSDK/ApphudStoreKitWrapper.swift
+++ b/ApphudSDK/ApphudStoreKitWrapper.swift
@@ -28,7 +28,7 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
     private var paymentCallback: ApphudTransactionCallback?
     private var purchasingProductID: String?
     private weak var purchasingPayment: SKPayment?
-    internal var customProductsFetchedBlock: ApphudStoreKitProductsCallback?
+    internal var customProductsFetchedBlocks = [ApphudStoreKitProductsCallback]()
 
     private var refreshRequest: SKReceiptRefreshRequest?
 
@@ -49,8 +49,8 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
             callback(products)
             NotificationCenter.default.post(name: Apphud.didFetchProductsNotification(), object: self.products)
             ApphudInternal.shared.delegate?.apphudDidFetchStoreKitProducts?(self.products)
-            self.customProductsFetchedBlock?(self.products)
-            self.customProductsFetchedBlock = nil
+            self.customProductsFetchedBlocks.forEach { block in block(self.products) }
+            self.customProductsFetchedBlocks.removeAll()
         }
     }
 
@@ -123,7 +123,7 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
         if transaction.payment.productIdentifier == self.purchasingProductID {
             self.purchasingProductID = nil
             if self.paymentCallback != nil {
-                self.paymentCallback?(transaction, nil)
+                self.paymentCallback?(transaction, transaction.error)
             } else {
                 finishTransaction(transaction)
             }


### PR DESCRIPTION
* Fixed bug that error was always `nil` when using `Apphud.purchaseWithoutValidation` method
* Improved retries logic when there is no Internet Connection
* Improved products fetch and refresh callbacks; make array of blocks instead of overwriting block variable.