### PR TITLE
Fix/checkPromoEligibilities

### DIFF
--- a/ApphudSDK/Internal/ApphudInternal+Eligibility.swift
+++ b/ApphudSDK/Internal/ApphudInternal+Eligibility.swift
@@ -62,7 +62,7 @@ extension ApphudInternal {
             if await (currentUser?.subscriptions.first(where: { $0.productId == product.productIdentifier })) != nil {
                 response[product.productIdentifier] = true
             } else if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) {
-                for await result in StoreKit.Transaction.currentEntitlements {
+                for await result in StoreKit.Transaction.all {
                     if case .verified(let transaction) = result {
                         let productStruct = try? await ApphudAsyncStoreKit.shared.fetchProduct(transaction.productID)
                         if productStruct?.subscription != nil && productStruct?.subscription?.subscriptionGroupID == product.subscriptionGroupIdentifier {


### PR DESCRIPTION
As stated in [docs](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/implementing_promotional_offers_in_your_app#3150971), user is eligible for promo, if they have ever purchased a subscription from the group, without a requirement to be currently subscribed.
Thats why, the correct way to check for promo eligibility would be by checking `StoreKit.Transaction.all` and not only current entitlements.