### PR TITLE
swift-tools-version set to 5.3 to support PrivacyInfo.xcprivacy processing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(name: "ApphudSDK",


### PR DESCRIPTION
Problem with `.target` method within Package.swift
```
.target(name: "ApphudSDK",
            path: "ApphudSDK",
            resources: [
                .copy("../ApphudSDK/PrivacyInfo.xcprivacy")
            ])
```
This signature is available from version 5.3.

Our company uses Tuist to integrate ApphudSDK. It throws an error.
```
error: 'target(name:dependencies:path:exclude:sources:resources:publicHeadersPath:cSettings:cxxSettings:swiftSettings:linkerSettings:)' is unavailable
                      targets: [.target(name: "ApphudSDK",
                                 ^~~~~~
PackageDescription.Target:63:24: note: 'target(name:dependencies:path:exclude:sources:resources:publicHeadersPath:cSettings:cxxSettings:swiftSettings:linkerSettings:)' was introduced in PackageDescription 5.3
```