### PR TITLE
Added new methods to log shown and closed paywall

### DIFF
--- a/Sources/Public/Apphud.swift
+++ b/Sources/Public/Apphud.swift
@@ -292,6 +292,16 @@ final public class Apphud: NSObject {
         ApphudLoggerService.shared.paywallShown(paywallId: paywall.id, placementId: paywall.placementId)
     }
 
+	/**
+	Logs a "Paywall Shown" event which is required for A/B Testing analytics.
+
+	- parameter paywallId: Identifier of a `ApphudPaywall` that was shown to the user.
+	- parameter placementId: Iidentifier of a `ApphudPlacement` that was shown to the user.
+	*/
+	@objc public static func paywallShown(paywallId: String?, placementId: String?) {
+		ApphudLoggerService.shared.paywallShown(paywallId: paywallId, placementId: placementId)
+	}
+
     /**
     Logs a "Paywall Closed" event which is required for A/B Testing analytics.
 
@@ -300,6 +310,16 @@ final public class Apphud: NSObject {
     @objc public static func paywallClosed(_ paywall: ApphudPaywall) {
         ApphudLoggerService.shared.paywallClosed(paywallId: paywall.id, placementId: paywall.placementId)
     }
+
+	/**
+	Logs a "Paywall Closed" event which is required for A/B Testing analytics.
+
+	- parameter paywallId: Identifier of a `ApphudPaywall` that was shown to the user.
+	- parameter placementId: Iidentifier of a `ApphudPlacement` that was shown to the user.
+	*/
+	@objc public static func paywallClosed(paywallId: String?, placementId: String?) {
+		ApphudLoggerService.shared.paywallClosed(paywallId: paywallId, placementId: placementId)
+	}
 
     // MARK: - Products
     /**


### PR DESCRIPTION
* Added new methods `paywallShown` and `paywallClosed` with parameters `paywallId` and `placementId` in addition to existing methods with same names to allow log events by using only simple parameters and not entire `ApphudPaywall` entity.