### PR TITLE
Fix/withCheckedContinuation crash

### DIFF
--- a/Sources/Internal/ApphudInternal+Currency.swift
+++ b/Sources/Internal/ApphudInternal+Currency.swift
@@ -27,7 +27,7 @@ extension ApphudInternal {
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     private func fetchStorefrontCurrency() async {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             fetchCurrencyWithMaxTimeout {
                 continuation.resume()
             }
@@ -97,7 +97,7 @@ extension ApphudInternal {
             })
 
             await continueToFetchStoreKitProducts(maxAttempts: APPHUD_DEFAULT_RETRIES)
-            skProducts = await withCheckedContinuation { continuation in
+            skProducts = await withUnsafeContinuation { continuation in
                 Task { @MainActor in
                     performWhenStoreKitProductFetched(maxAttempts: 3) { _ in
                         continuation.resume(returning: ApphudStoreKitWrapper.shared.products)

--- a/Sources/Internal/ApphudInternal+Product.swift
+++ b/Sources/Internal/ApphudInternal+Product.swift
@@ -53,7 +53,7 @@ extension ApphudInternal {
             _ = await fetchPermissionGroups()
         }
         
-        return await withCheckedContinuation({ continuation in
+        return await withUnsafeContinuation({ continuation in
             performWhenUserRegistered(allowFailure: true) { @MainActor in
                 continuation.resume(returning: self.allAvailableProductIDs())
             }
@@ -165,7 +165,7 @@ extension ApphudInternal {
     }
 
     internal func fetchPermissionGroups() async -> [ApphudGroup]? {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             ApphudInternal.shared.getProductGroups { groups, _, _ in
                 Task {
                     if let g = groups {

--- a/Sources/Internal/ApphudInternal+Purchase.swift
+++ b/Sources/Internal/ApphudInternal+Purchase.swift
@@ -93,7 +93,7 @@ extension ApphudInternal {
             try? await ApphudAsyncStoreKit.shared.fetchProductIfNeeded(productID)
             let receipt = await appStoreReceipt()
             let isRecentlyPurchased: Bool = purchaseDate > Date().addingTimeInterval(-600)
-            return await withCheckedContinuation { continuation in
+            return await withUnsafeContinuation { continuation in
                 performWhenUserRegistered {
                     apphudLog("Submitting transaction \(transactionId), \(productID) from StoreKit2..")
 
@@ -125,7 +125,7 @@ extension ApphudInternal {
 
         apphudLog("App Store receipt is missing on device, refreshing...")
 
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             ApphudStoreKitWrapper.shared.refreshReceipt {
                 continuation.resume(returning: apphudReceiptDataString())
             }
@@ -422,7 +422,7 @@ extension ApphudInternal {
     @MainActor
     @available(iOS 13.0.0, macOS 11.0, watchOS 6.0, tvOS 13.0, *)
     internal func purchase(productId: String, product: ApphudProduct?, validate: Bool, isPurchasing: Binding<Bool>? = nil, value: Double? = nil) async -> ApphudPurchaseResult {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             isPurchasing?.wrappedValue = true
             purchase(productId: productId, product: product, validate: validate, callback: { result in
                 isPurchasing?.wrappedValue = false

--- a/Sources/Internal/ApphudInternal+UserUpdate.swift
+++ b/Sources/Internal/ApphudInternal+UserUpdate.swift
@@ -91,7 +91,7 @@ extension ApphudInternal {
 
         let fields = initialCall ? ["user_id": self.currentUserID, "initial_call": true] : [:]
 
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             updateUser(fields: fields, delay: delay) { (result, _, data, error, code, duration, attempts) in
 
                 Task {

--- a/Sources/Internal/ApphudStoreKitWrapper.swift
+++ b/Sources/Internal/ApphudStoreKitWrapper.swift
@@ -102,7 +102,7 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
         let fetcher = ApphudProductsFetcher()
         fetchers.insert(fetcher)
         
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             fetcher.fetchStoreKitProducts(identifiers: identifiers) { products, error, ftchr in
                 let existingIDS = self.products.map { $0.productIdentifier }
                 let uniqueProducts = products.filter { !existingIDS.contains($0.productIdentifier) }
@@ -128,7 +128,7 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
             return availableProduct
         }
 
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             fetchProducts(productIds: [productId]) { prds in
                 continuation.resume(returning: prds?.first(where: { $0.productIdentifier == productId }))
             }
@@ -148,7 +148,7 @@ internal class ApphudStoreKitWrapper: NSObject, SKPaymentTransactionObserver, SK
             return available
         }
 
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             fetchProducts(productIds: productIds) { products in
                 continuation.resume(returning: products)
             }

--- a/Sources/Public/Apphud.swift
+++ b/Sources/Public/Apphud.swift
@@ -133,7 +133,7 @@ final public class Apphud: NSObject {
      */
     @MainActor
     public static func placements(maxAttempts: Int = APPHUD_DEFAULT_RETRIES) async -> [ApphudPlacement] {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             ApphudInternal.shared.fetchOfferingsFull(maxAttempts: maxAttempts) { error in
                 continuation.resume(returning: ApphudInternal.shared.placements)
             }
@@ -289,7 +289,7 @@ final public class Apphud: NSObject {
      - Returns: An array of `SKProduct` objects corresponding to the products added in the Apphud > Product Hub > Products section.
      */
     @objc public static func fetchSKProducts(maxAttempts: Int = APPHUD_DEFAULT_RETRIES) async -> [SKProduct] {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             Apphud.fetchProducts(maxAttempts: maxAttempts) { prds, _ in continuation.resume(returning: prds) }
         }
     }
@@ -558,7 +558,7 @@ final public class Apphud: NSObject {
      - Returns: An optional `Error`. If the error is `nil`, you can check the user's premium status using the `Apphud.hasActiveSubscription()` or `Apphud.hasPremiumAccess()` methods.
      */
     @MainActor @objc @discardableResult public static func restorePurchases() async -> Error? {
-        return await withCheckedContinuation({ continunation in
+        return await withUnsafeContinuation({ continunation in
             Task { @MainActor in
                 ApphudInternal.shared.restorePurchases { _, _, error in
                     continunation.resume(returning: error)


### PR DESCRIPTION
It is a popular crash among many libraries and developers using Xcode 16+ to release their apps. First iOS 18 beta's had this issue, so not many crashes occur now, but they still do in our app.
![CleanShot 2025-01-07 at 01 06 49](https://github.com/user-attachments/assets/a78196d3-c69b-4bf8-b331-1ee045c07869)

More info can be found by these links:
- https://github.com/swiftlang/swift/issues/75952
- https://github.com/RevenueCat/purchases-ios/issues/4177
- https://github.com/swiftlang/swift/pull/76218#issuecomment-2375423832
- https://developer.apple.com/forums/thread/761580
- https://forums.swift.org/t/global-with-concurrency-functions-crash-on-catalyst-designed-for-ipad-on-macos/74823/11