### PR TITLE
[APPHUD-336] Add screenName property to ApphudPaywall

### DIFF
--- a/Sources/Public/ApphudPaywall.swift
+++ b/Sources/Public/ApphudPaywall.swift
@@ -77,6 +77,13 @@ public class ApphudPaywall: NSObject, Codable, ObservableObject {
         paywallVariationName
     }
 
+    /**
+     Name of the paywall's visual Screen as set in the Apphud Dashboard, if the paywall has one.
+     */
+    @objc public var screenName: String? {
+        screen?.name
+    }
+
     private var paywallExperimentName: String?
     private var paywallVariationName: String?
 

--- a/Sources/Public/ApphudPaywallScreen.swift
+++ b/Sources/Public/ApphudPaywallScreen.swift
@@ -9,6 +9,12 @@ import Foundation
 public class ApphudPaywallScreen: Codable {
 
     public var id: String
+
+    /**
+     Screen name as set in the Apphud Dashboard.
+     */
+    public var name: String?
+
     public var defaultURL: String?
     public var urls: [String: String]
 


### PR DESCRIPTION
## What
Exposes the visual Screen's name from the Apphud Dashboard on the paywall model:
- `ApphudPaywallScreen` gains a public `name: String?`, decoded from the `name` key the backend now includes in the `screen` object of every paywall payload.
- `ApphudPaywall` gains a computed `@objc public var screenName: String?` mirroring `screen?.name`.

## Why
The backend now returns the screen name in all SDK paywall responses (v1 customer registration incl. placements, `GET /v2/paywall_configs/:identifier`), but the SDK models dropped it. Apps need `paywall.screenName` for analytics/UI without extra requests.

## Compatibility
- `name` is optional: legacy cached payloads without the key decode to `nil` (synthesized Codable, verified incl. cache round-trip with the SDK's snake_case strategies).
- No existing behavior changed; `createWithCustomData` paywalls keep `screenName == nil`.

## Testing
- `swift build` + `xcodebuild` for iOS Simulator — green.
- Decode/encode checks against the real backend payload shape (name present / key absent / explicit `null` / no screen / cache round-trip) — 7/7 green. Run as an external harness because the repo has no unit-test target on `master` (adding one here would conflict with the pending StoreKit 2 branch).
