### PR TITLE
[APPHUD-336] Bump version to 4.5.0

### DIFF
--- a/ApphudSDK.podspec
+++ b/ApphudSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ApphudSDK'
-  s.version          = '4.4.8'
+  s.version          = '4.5.0'
   s.summary          = 'Build and Measure In-App Subscriptions on iOS.'
   s.description      = 'Apphud covers every aspect when it comes to In-App Subscriptions from integration to analytics on iOS and Android.'
   s.homepage         = 'https://github.com/apphud/ApphudSDK'

--- a/Sources/Public/Apphud.swift
+++ b/Sources/Public/Apphud.swift
@@ -14,7 +14,7 @@ import Foundation
 import UserNotifications
 import SwiftUI
 
-internal let apphud_sdk_version = "4.4.8"
+internal let apphud_sdk_version = "4.5.0"
 
 public enum ApphudDeeplinkAttributionKind {
     case direct


### PR DESCRIPTION
Prepares the 4.5.0 release: version bump in `ApphudSDK.podspec` and `apphud_sdk_version`. The release contains one feature: `ApphudPaywall.screenName` (#142).
