### PR TITLE
Release 4.5.0

### DIFF
--- a/ApphudSDK.podspec
+++ b/ApphudSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ApphudSDK'
-  s.version          = '4.4.8'
+  s.version          = '4.5.0'
   s.summary          = 'Build and Measure In-App Subscriptions on iOS.'
   s.description      = 'Apphud covers every aspect when it comes to In-App Subscriptions from integration to analytics on iOS and Android.'
   s.homepage         = 'https://github.com/apphud/ApphudSDK'

--- a/Sources/Public/Apphud.swift
+++ b/Sources/Public/Apphud.swift
@@ -14,7 +14,7 @@ import Foundation
 import UserNotifications
 import SwiftUI
 
-internal let apphud_sdk_version = "4.4.8"
+internal let apphud_sdk_version = "4.5.0"
 
 public enum ApphudDeeplinkAttributionKind {
     case direct

--- a/Sources/Public/ApphudPaywall.swift
+++ b/Sources/Public/ApphudPaywall.swift
@@ -77,6 +77,13 @@ public class ApphudPaywall: NSObject, Codable, ObservableObject {
         paywallVariationName
     }
 
+    /**
+     Name of the paywall's visual Screen as set in the Apphud Dashboard, if the paywall has one.
+     */
+    @objc public var screenName: String? {
+        screen?.name
+    }
+
     private var paywallExperimentName: String?
     private var paywallVariationName: String?
 

--- a/Sources/Public/ApphudPaywallScreen.swift
+++ b/Sources/Public/ApphudPaywallScreen.swift
@@ -9,6 +9,12 @@ import Foundation
 public class ApphudPaywallScreen: Codable {
 
     public var id: String
+
+    /**
+     Screen name as set in the Apphud Dashboard.
+     */
+    public var name: String?
+
     public var defaultURL: String?
     public var urls: [String: String]
 


### PR DESCRIPTION
## 4.5.0
- Added `screenName` property to `ApphudPaywall` and `name` to `ApphudPaywallScreen` — the visual Screen's name from the Apphud Dashboard (#142)

After merge: tag `4.5.0` (SPM picks it up automatically), `pod trunk push ApphudSDK.podspec`, GitHub Release.
